### PR TITLE
Added README to content repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
-# exercises-circe
+#Scala Exercises - Circe library
+
+------------------------
+
+This repository hosts a content library for the [Scala Exercises](https://www.scala-exercises.org/) platform, including interactive exercises related to the [Circe](https://github.com/travisbrown/circe) JSON library.
+
+## About Scala exercises
+
+"Scala Exercises" brings exercises for the Stdlib, Cats, Shapeless and many other great libraries for Scala to your browser. Offering hundreds of solvable exercises organized into several categories covering the basics of the Scala language and it's most important libraries.
+
+Scala Exercises is available at [scala-exercises.org](https://scala-exercises.org).
+
+## Contributing
+
+Contributions welcome! Please join our [Gitter channel](https://gitter.im/scala-exercises/scala-exercises)
+to get involved, or visit our [GitHub site](https://github.com/scala-exercises).
+
+##License
+
+Copyright (C) 2015-2016 47 Degrees, LLC.
+Reactive, scalable software solutions.
+http://47deg.com
+hello@47deg.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
This PR adds a README to the content library repository, in order to make ut more easily identifiable. This PR is part of a fix for issue: scala-exercises/scala-exercises#494

Could you please review? @raulraja @dialelo @juanpedromoreno.

Thanks!
