### PR TITLE
Update Scala 2.12.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: scala
 
 scala:
-- 2.11.11
+- 2.12.10
 
 jdk:
 - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ scala:
 - 2.12.10
 
 jdk:
-- oraclejdk8
+- openjdk8
 
 before_install:
 - if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then

--- a/build.sbt
+++ b/build.sbt
@@ -1,25 +1,29 @@
-val scalaExercisesV = "0.4.0-SNAPSHOT"
-val circeVersion = "0.7.0"
+import ProjectPlugin.autoImport._
+
+val scalaExercisesV = "0.5.0-SNAPSHOT"
 
 def dep(artifactId: String) = "org.scala-exercises" %% artifactId % scalaExercisesV
 
 lazy val `circe` = (project in file("."))
   .enablePlugins(ExerciseCompilerPlugin)
   .settings(
-    name         := "exercises-circe",
+    name := "exercises-circe",
     libraryDependencies ++= Seq(
       dep("exercise-compiler"),
       dep("definitions"),
-      %%("circe-core"),
-      %%("circe-generic"),
-      %%("circe-parser"),
-      "io.circe" %% "circe-optics" % circeVersion,
-      %%("shapeless"),
-      %%("cats-core"),
-      %%("scalatest"),
-      %%("scalacheck"),
-      %%("scheckShapeless")
-    )
+      "io.circe" %% "circe-core"           % V.circe,
+      "io.circe" %% "circe-generic"        % V.circe,
+      "io.circe" %% "circe-parser"         % V.circe,
+      "io.circe" %% "circe-generic-extras" % V.circeGenericExtras,
+      "io.circe" %% "circe-shapes"         % V.circe,
+      "io.circe" %% "circe-optics"         % V.circeOptics,
+      %%("shapeless", V.shapeless),
+      %%("cats-core", V.cats),
+      %%("scalatest", V.scalatest),
+      %%("scalacheck", V.scalacheck),
+      "com.github.alexarchambault" %% "scalacheck-shapeless_1.14" % V.scalacheckShapeless
+    ),
+    addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
   )
 
 // Distribution

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -1,16 +1,34 @@
-import de.heikoseeberger.sbtheader.HeaderPattern
+import scala.language.reflectiveCalls
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport._
+import de.heikoseeberger.sbtheader.License._
 import sbt.Keys._
 import sbt._
+import sbtorgpolicies.OrgPoliciesPlugin.autoImport._
 import sbtorgpolicies._
 import sbtorgpolicies.model._
-import sbtorgpolicies.OrgPoliciesPlugin.autoImport._
 
 object ProjectPlugin extends AutoPlugin {
 
   override def trigger: PluginTrigger = allRequirements
 
   override def requires: Plugins = plugins.JvmPlugin && OrgPoliciesPlugin
+
+  object autoImport {
+
+    lazy val V = new {
+      val scala212: String            = "2.12.10"
+      val cats: String                = "2.0.0"
+      val circe: String               = "0.12.3"
+      val circeOptics: String         = "0.12.0"
+      val circeGenericExtras: String  = "0.12.2"
+      val shapeless: String           = "2.3.3"
+      val scalatest: String           = "3.0.8"
+      val scalacheck: String          = "1.14.2"
+      val scalacheckShapeless: String = "1.2.3"
+    }
+  }
+
+  import autoImport._
 
   override def projectSettings: Seq[Def.Setting[_]] =
     Seq(
@@ -25,23 +43,17 @@ object ProjectPlugin extends AutoPlugin {
         organizationEmail = "hello@47deg.com"
       ),
       orgLicenseSetting := ApacheLicense,
-      scalaVersion := "2.11.11",
+      scalaVersion := V.scala212,
       scalaOrganization := "org.scala-lang",
-      crossScalaVersions := Seq("2.11.11"),
       resolvers ++= Seq(
         Resolver.mavenLocal,
         Resolver.sonatypeRepo("snapshots"),
         Resolver.sonatypeRepo("releases")
       ),
-      scalacOptions := sbtorgpolicies.model.scalacCommonOptions,
-      headers := Map(
-        "scala" -> (HeaderPattern.cStyleBlockComment,
-          s"""|/*
-              | * scala-exercises - ${name.value}
-              | * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
-              | */
-              |
-            |""".stripMargin)
-      )
+      scalacOptions ++= scalacCommonOptions,
+      headerLicense := Some(Custom(s"""| scala-exercises - ${name.value}
+                                       | Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+                                       |
+                                       |""".stripMargin))
     )
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,5 +2,5 @@ resolvers ++= Seq(
   Resolver.sonatypeRepo("snapshots")
 )
 
-addSbtPlugin("org.scala-exercises" % "sbt-exercise" % "0.4.0-SNAPSHOT", "0.13", "2.10")
-addSbtPlugin("com.47deg"         % "sbt-org-policies" % "0.5.13")
+addSbtPlugin("org.scala-exercises" % "sbt-exercise"     % "0.5.0-SNAPSHOT")
+addSbtPlugin("com.47deg"           % "sbt-org-policies" % "0.12.0-M3")

--- a/src/main/scala/circelib/ADTSection.scala
+++ b/src/main/scala/circelib/ADTSection.scala
@@ -1,0 +1,155 @@
+/*
+ *  scala-exercises - exercises-circe
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ */
+
+package circelib
+
+import io.circe.Error
+import io.circe.syntax._
+import org.scalaexercises.definitions.Section
+import org.scalatest.{FlatSpec, Matchers}
+
+/**
+ * ==ADTs encoding and decoding==
+ *
+ * The most straightforward way to encode / decode ADTs is by using generic derivation for the case classes but
+ * explicitly defined instances for the ADT type.
+ *
+ * @param name ADT (Algebraic Data Types)
+ */
+object ADTSection extends FlatSpec with Matchers with Section {
+
+  import helpers.ADTHelpers._
+
+  /**
+   * Consider the following ADT:
+   * {{{
+   * sealed trait Event
+   *
+   * case class Foo(i: Int) extends Event
+   * case class Bar(s: String) extends Event
+   * case class Baz(c: Char) extends Event
+   * case class Qux(values: List[String]) extends Event
+   * }}}
+   *
+   * And the encoder / decoder instances:
+   * {{{
+   * import cats.syntax.functor._
+   * import io.circe.{ Decoder, Encoder }, io.circe.generic.auto._
+   * import io.circe.syntax._
+   *
+   * object GenericDerivation {
+   *   implicit val encodeEvent: Encoder[Event] = Encoder.instance {
+   *     case foo @ Foo(_) => foo.asJson
+   *     case bar @ Bar(_) => bar.asJson
+   *     case baz @ Baz(_) => baz.asJson
+   *     case qux @ Qux(_) => qux.asJson
+   *   }
+   *
+   *   implicit val decodeEvent: Decoder[Event] =
+   *     List[Decoder[Event]](
+   *       Decoder[Foo].widen,
+   *       Decoder[Bar].widen,
+   *       Decoder[Baz].widen,
+   *       Decoder[Qux].widen
+   *     ).reduceLeft(_ or _)
+   * }
+   * }}}
+   *
+   * Note that we have to call widen (which is provided by Cats’s Functor syntax, which we bring into scope with
+   * the first import) on the decoders because the Decoder type class is not covariant. The invariance of circe’s
+   * type classes is a matter of some controversy (Argonaut for example has gone from invariant to covariant and
+   * back), but it has enough benefits that it’s unlikely to change, which means we need workarounds like this
+   * occasionally.
+   *
+   * It’s also worth noting that our explicit Encoder and Decoder instances will take precedence over the
+   * generically-derived instances we would otherwise get from the io.circe.generic.auto._ import (see slides from
+   * Travis Brown’s talk here for some discussion of how this prioritization works).
+   *
+   * We can use these instances like this:
+   */
+  def genericDerivation(res0: Either[Error, Foo], res1: String) = {
+    import GenericDerivation._
+    import io.circe.parser.decode
+
+    decode[Event]("""{ "i": 1000 }""") shouldBe res0
+    (Foo(100): Event).asJson.noSpaces shouldBe res1
+  }
+
+  // TODO: Example from documentation not compiling (https://github.com/circe/circe/issues/1125)
+  /*
+  /**
+   * =A more generic solution=
+   *
+   * We can avoid the fuss of writing out all the cases by using the `circe-shapes` module:
+   * {{{
+   * // To suppress previously imported implicit codecs.
+   * import GenericDerivation.{ decodeEvent => _, encodeEvent => _ }
+   *
+   * object ShapesDerivation {
+   *   import io.circe.shapes
+   *   import shapeless.{ Coproduct, Generic }
+   *
+   *   implicit def encodeAdtNoDiscr[A, Repr <: Coproduct](implicit
+   *     gen: Generic.Aux[A, Repr],
+   *     encodeRepr: Encoder[Repr]
+   *   ): Encoder[A] = encodeRepr.contramap(gen.to)
+   *
+   *   implicit def decodeAdtNoDiscr[A, Repr <: Coproduct](implicit
+   *     gen: Generic.Aux[A, Repr],
+   *     decodeRepr: Decoder[Repr]
+   *   ): Decoder[A] = decodeRepr.map(gen.from)
+   *
+   * }
+   *
+   * And then:
+   * }}}
+   */
+  def shapesDerivation(res0: Either[Error, Event], res1: String) = {
+    import ShapesDerivation._
+
+    import io.circe.parser.decode, io.circe.syntax._
+
+    decode[Event]("""{ "i": 1000 }""") shouldBe res0
+    (Foo(100): Event).asJson.noSpaces shouldBe res1
+  }
+  /**
+   * This will work for any ADT anywhere that `encodeAdtNoDiscr` and `decodeAdtNoDiscr` are in scope. If we wanted it
+   * to be more limited, we could replace the generic `A` with our ADT types in those definitions, or we could make
+   * the definitions non-implicit and define implicit instances explicitly for the ADTs we want encoded this way.
+   *
+   * The main drawback of this approach (apart from the extra `circe-shapes` dependency) is that the constructors
+   * will be tried in alphabetical order, which may not be what we want if we have ambiguous case classes (where
+   * the member names and types are the same).
+   */
+
+   */
+
+  /**
+   *  =The future=
+   *
+   * The generic-extras module provides a little more configurability in this respect. We can write the following,
+   * for example:
+   * {{{
+   * // Same as above
+   * import ShapesDerivation.{encodeAdtNoDiscr => _, decodeAdtNoDiscr => _}
+   *
+   * object GenericExtraDerivation {
+   *   import io.circe.generic.extras.Configuration
+   *
+   *   implicit val genDevConfig: Configuration =
+   *     Configuration.default.withDiscriminator("what_am_i")
+   * }
+   * }}}
+   */
+  def genericExtrasADT(res0: Either[Error, Event]) = {
+    import GenericExtraDerivation._
+    import io.circe.parser.decode
+    import io.circe.generic.extras.auto._
+
+    decode[Event]("""{ "i": 1000, "what_am_i": "Foo" }""") shouldBe res0
+  }
+
+}

--- a/src/main/scala/circelib/CirceLibrary.scala
+++ b/src/main/scala/circelib/CirceLibrary.scala
@@ -19,7 +19,13 @@ object CirceLibrary extends definitions.Library {
   override def color = Some("#996666")
 
   override def sections =
-    List(JsonSection, TraversingSection, OpticsSection, EncodingDecodingSection)
+    List(
+      JsonSection,
+      TraversingSection,
+      EncodingDecodingSection,
+      CustomCodecsSection,
+      ADTSection,
+      OpticsSection)
 
   override def logoPath = "circe"
 }

--- a/src/main/scala/circelib/CirceLibrary.scala
+++ b/src/main/scala/circelib/CirceLibrary.scala
@@ -1,6 +1,7 @@
 /*
- * scala-exercises - exercises-circe
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-circe
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package circelib

--- a/src/main/scala/circelib/CustomCodecsSection.scala
+++ b/src/main/scala/circelib/CustomCodecsSection.scala
@@ -12,9 +12,7 @@ import org.scalaexercises.definitions.Section
 import org.scalatest.{FlatSpec, Matchers}
 
 /**
- * @param name Custom codecs
- *
- * ==Custom encoders/decoders==
+ * =Custom encoders/decoders=
  *
  * If you want to write your own codec instead of using automatic or semi-automatic derivation, you can do so in a couple of ways.
  *
@@ -45,11 +43,13 @@ import org.scalatest.{FlatSpec, Matchers}
  *    Either.catchNonFatal(Instant.parse(str)).leftMap(t => "Instant")
  * }
  * }}}
+ *
+ * @param name Custom codecs
  */
 object CustomCodecsSection extends FlatSpec with Matchers with Section {
 
   /**
-   * ==Custom key types==
+   * =Custom key types=
    *
    * If you need to encode/decode `Map[K, V]` where `K` is not `String` (or `Symbol`, `Int`, `Long`, etc), you need to provide a `KeyEncoder`
    * and/or `KeyDecoder` for your custom key type.
@@ -81,11 +81,11 @@ object CustomCodecsSection extends FlatSpec with Matchers with Section {
    *
    * What would be returned as a result of decoding and traversing the returned `Map`:
    */
-  def mapJson(res0: Either[String, Int]): Unit =
+  def mapJson(res0: Either[String, Int]) =
     json.hcursor.downField("hello").as[Int] should be(res0)
 
   /**
-   * ==Custom key mappings via annotations==
+   * =Custom key mappings via annotations=
    *
    * It’s often necessary to work with keys in your JSON objects that aren’t idiomatic case class member names in
    * Scala. While the standard generic derivation doesn’t support this use case, the experimental circe-generic-extras

--- a/src/main/scala/circelib/CustomCodecsSection.scala
+++ b/src/main/scala/circelib/CustomCodecsSection.scala
@@ -1,0 +1,136 @@
+/*
+ *  scala-exercises - exercises-circe
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ */
+
+package circelib
+
+import io.circe.generic.extras._, io.circe.syntax._
+import circelib.helpers.CustomCodecsHelpers.json
+import org.scalaexercises.definitions.Section
+import org.scalatest.{FlatSpec, Matchers}
+
+/**
+ * @param name Custom codecs
+ *
+ * ==Custom encoders/decoders==
+ *
+ * If you want to write your own codec instead of using automatic or semi-automatic derivation, you can do so in a couple of ways.
+ *
+ * Firstly, you can write a new `Encoder[A]` and `Decoder[A]` from scratch
+ *
+ * {{{
+ * class Thing()
+ *
+ * implicit val encodeFoo: Encoder[Thing] = new Encoder[Thing] {
+ *    final def apply(a: Thing): Json = ??? // your implementation goes here
+ * }
+ *
+ * implicit val decodeFoo: Decoder[Thing] = new Decoder[Thing] {
+ *    final def apply(c: HCursor): Decoder.Result[Thing] = Left(DecodingFailure("Not implemented yet", c.history))
+ * }
+ * }}}
+ *
+ * But in many cases you might find it more convenient to piggyback on top of the decoders that are already available. For example, a codec for
+ * `java.time.Instant` might look like this:
+ * {{{
+ * import cats.syntax.either._
+ *
+ * import java.time.Instant
+ *
+ * implicit val encodeInstant: Encoder[Instant] = Encoder.encodeString.contramap[Instant](_.toString)
+ *
+ * implicit val decodeInstant: Decoder[Instant] = Decoder.decodeString.emap { str =>
+ *    Either.catchNonFatal(Instant.parse(str)).leftMap(t => "Instant")
+ * }
+ * }}}
+ */
+object CustomCodecsSection extends FlatSpec with Matchers with Section {
+
+  /**
+   * ==Custom key types==
+   *
+   * If you need to encode/decode `Map[K, V]` where `K` is not `String` (or `Symbol`, `Int`, `Long`, etc), you need to provide a `KeyEncoder`
+   * and/or `KeyDecoder` for your custom key type.
+   *
+   * For example:
+   * {{{
+   *   import io.circe._, import io.circe.syntax._
+   *
+   *   case class Foo(value: String)
+   *
+   *
+   *   implicit val fooKeyEncoder = new KeyEncoder[Foo] {
+   *     override def apply(foo: Foo): String = foo.value
+   *   }
+   *
+   *   val map = Map[Foo, Int](
+   *     Foo("hello") -> 123,
+   *     Foo("world") -> 456
+   *   }
+   *
+   *   val json = map.asJson
+   *
+   *   implicit val fooKeyDecoder = new KeyDecoder[Foo] {
+   *     override def apply(key: String): Option[Foo] = Some(Foo(key))
+   *   }
+   *
+   *   json.as[Map[Foo, Int]]
+   * }}}
+   *
+   * What would be returned as a result of decoding and traversing the returned `Map`:
+   */
+  def mapJson(res0: Either[String, Int]): Unit =
+    json.hcursor.downField("hello").as[Int] should be(res0)
+
+  /**
+   * ==Custom key mappings via annotations==
+   *
+   * It’s often necessary to work with keys in your JSON objects that aren’t idiomatic case class member names in
+   * Scala. While the standard generic derivation doesn’t support this use case, the experimental circe-generic-extras
+   * module does provide two ways to transform your case class member names during encoding and decoding.
+   *
+   * In many cases the transformation is as simple as going from camel case to snake case, in which case all you need
+   * is a custom implicit configuration:
+   * {{{
+   *   import io.circe.generic.extras._, io.circe.syntax._
+   * }}}
+   *
+   */
+  def basicCustomKeyMapping(res0: String) = {
+    implicit val config: Configuration = Configuration.default.withSnakeCaseMemberNames
+
+    @ConfiguredJsonCodec case class User(firstName: String, lastName: String)
+
+    User("Foo", "McBar").asJson.noSpaces shouldBe res0
+  }
+
+  /**
+   * In other cases you may need more complex mappings. These can be provided as a function:
+   */
+  def complexCustomKeyMapping(res0: String) = {
+    implicit val config: Configuration = Configuration.default.copy(
+      transformMemberNames = {
+        case "i"   => "my-int"
+        case other => other
+      }
+    )
+
+    @ConfiguredJsonCodec case class Bar(i: Int, s: String)
+
+    Bar(13, "Qux").asJson.noSpaces shouldBe res0
+  }
+
+  /**
+   * Since this is a common use case, we also support for mapping member names via an annotation:
+   */
+  def mappingMemberAnnotation(res0: String) = {
+    implicit val config: Configuration = Configuration.default
+
+    @ConfiguredJsonCodec case class Bar(@JsonKey("my-int") i: Int, s: String)
+
+    Bar(13, "Qux").asJson.noSpaces shouldBe res0
+  }
+
+}

--- a/src/main/scala/circelib/EncodingDecodingSection.scala
+++ b/src/main/scala/circelib/EncodingDecodingSection.scala
@@ -1,6 +1,7 @@
 /*
- * scala-exercises - exercises-circe
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-circe
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package circelib
@@ -16,8 +17,6 @@ object EncodingDecodingSection
     extends FlatSpec
     with Matchers
     with org.scalaexercises.definitions.Section {
-
-  import circelib.helpers.EncodingHelpers._
 
   /**
    * Circe uses `Encoder` and `Decoder` type classes for encoding and decoding. An `Encoder[A]` instance provides a function
@@ -63,7 +62,7 @@ object EncodingDecodingSection
   }
 
   /**
-   * ==Semi-automatic derivation
+   * ==Semi-automatic derivation==
    *
    * Sometimes it's convenient to have an `Encoder` or `Decoder` defined in your code, and '''semi-automatic''' derivation can help. You´d write:
    *
@@ -123,7 +122,7 @@ object EncodingDecodingSection
    *  mapping it’s currently the best solution (although 0.6.0 introduces experimental configurable generic derivation in the circe-generic-extras module).
    *
    *
-   * ==Fully automatic derivation==
+   * ==Automatic derivation==
    *
    *  It is also possible to derive an `Encoder` and `Decoder` for many types with no boilerplate at all.
    *  Circe uses [[https://github.com/milessabin/shapeless shapeless]] to automatically derive the necessary type class instances:
@@ -141,71 +140,5 @@ object EncodingDecodingSection
 
     greetingJson.hcursor.downField("person").downField("name").as[String] should be(res0)
   }
-
-  /**
-   *  ==Custom encoders/decoders
-   *
-   *  If you want to write your own codec instead of using automatic or semi-automatic derivation, you can do so in a couple of ways.
-   *
-   *  Firstly, you can write a new `Encoder[A]` and `Decoder[A]` from scratch
-   *
-   *  {{{
-   *    class Thing()
-   *
-   *    implicit val encodeFoo: Encoder[Thing] = new Encoder[Thing] {
-   *       final def apply(a: Thing): Json = ??? // your implementation goes here
-   *    }
-   *
-   *    implicit val decodeFoo: Decoder[Thing] = new Decoder[Thing] {
-   *       final def apply(c: HCursor): Decoder.Result[Thing] = Left(DecodingFailure("Not implemented yet", c.history))
-   *    }
-   *  }}}
-   *
-   *  But in many cases you might find it more convenient to piggyback on top of the decoders that are already available. For example, a codec for
-   *  `java.time.Instant` might look like this:
-   *  {{{
-   *    import cats.syntax.either._
-   *
-   *    import java.time.Instant
-   *
-   *    implicit val encodeInstant: Encoder[Instant] = Encoder.encodeString.contramap[Instant](_.toString)
-   *
-   *    implicit val decodeInstant: Decoder[Instant] = Decoder.decodeString.emap { str =>
-   *       Either.catchNonFatal(Instant.parse(str)).leftMap(t => "Instant")
-   *     }
-   *  }}}
-   *
-   * ==Custom key types==
-   *
-   * If you need to encode/decode `Map[K, V]` where `K` is not `String` (or `Symbol`, `Int`, `Long`, etc), you need to provide a `KeyEncoder`
-   * and/or `KeyDecoder` for your custom key type.
-   *
-   * For example:
-   * {{{
-   *   import io.circe.syntax._
-   *
-   *   case class Foo(value: String)
-   *
-   *
-   *   implicit val fooKeyEncoder = new KeyEncoder[Foo] {
-   *     override def apply(foo: Foo): String = foo.value
-   *   }
-   *
-   *   val map = Map[Foo, Int](
-   *     Foo("hello") -> 123,
-   *     Foo("world") -> 456
-   *   }
-   *
-   *   implicit val fooKeyDecoder = new KeyDecoder[Foo] {
-   *     override def apply(key: String): Option[Foo] = Some(Foo(key))
-   *   }
-   *
-   *   json.as[Map[Foo, Int]]
-   * }}}
-   *
-   * What would be returned as a result of decoding and traversing the returned `Map`:
-   */
-  def mapJson(res0: Either[String, Int]): Unit =
-    json.hcursor.downField("hello").as[Int] should be(res0)
 
 }

--- a/src/main/scala/circelib/EncodingDecodingSection.scala
+++ b/src/main/scala/circelib/EncodingDecodingSection.scala
@@ -53,7 +53,7 @@ object EncodingDecodingSection
    *
    *  Let's decode a JSON String:
    */
-  def decodeJson(res0: Boolean, res1: Either[String, List[Int]]): Unit = {
+  def decodeJson(res0: Boolean, res1: Either[String, List[Int]]) = {
     val decodeList = decode[List[Int]]("[1, 2, 3]")
 
     decodeList.isRight should be(res0)
@@ -62,7 +62,7 @@ object EncodingDecodingSection
   }
 
   /**
-   * ==Semi-automatic derivation==
+   * =Semi-automatic derivation=
    *
    * Sometimes it's convenient to have an `Encoder` or `Decoder` defined in your code, and '''semi-automatic''' derivation can help. You´d write:
    *
@@ -81,7 +81,7 @@ object EncodingDecodingSection
    *   implicit val fooEncoder: Encoder[Foo] = deriveEncoder
    * }}}
    *
-   * ==@JsonCodec==
+   * =@JsonCodec=
    *
    *  The circe-generic projects includes a `@JsonCodec` annotation that simplifies the use of semi-automatic generic derivation:
    *
@@ -101,7 +101,7 @@ object EncodingDecodingSection
    *  This works both case classes and sealed trait hierarchies.
    *  NOTE: You will need the [[http://docs.scala-lang.org/overviews/macros/paradise.html Macro Paradise]] plugin to use annotation macros like `@JsonCodec`
    *
-   *  ==forProductN helper methods==
+   *  =forProductN helper methods=
    *
    * It's also possible to construct encoders and decoders for case class-like types in a relatively boilerplate-free way without generic derivation:
    * {{{
@@ -118,11 +118,11 @@ object EncodingDecodingSection
    *    }
    * }}}
    *
-   *  It’s not as clean or as maintainable as generic derivation, but it’s less magical, it requires nothing but circe-core, and if you need a custom name
-   *  mapping it’s currently the best solution (although 0.6.0 introduces experimental configurable generic derivation in the circe-generic-extras module).
+   *  It’s not as clean or as maintainable as generic derivation, but it’s less magical, it requires nothing but `circe-core`, and if you need a custom name
+   *  mapping it’s currently the best solution (although `0.6.0` introduces experimental configurable generic derivation in the `circe-generic-extras` module).
    *
    *
-   * ==Automatic derivation==
+   * =Automatic derivation=
    *
    *  It is also possible to derive an `Encoder` and `Decoder` for many types with no boilerplate at all.
    *  Circe uses [[https://github.com/milessabin/shapeless shapeless]] to automatically derive the necessary type class instances:
@@ -131,7 +131,7 @@ object EncodingDecodingSection
    *
    *  For this example we need to import `io.circe.generic.auto._`
    */
-  def automaticDerivation(res0: Either[String, String]): Unit = {
+  def automaticDerivation(res0: Either[String, String]) = {
     case class Person(name: String)
 
     case class Greeting(salutation: String, person: Person, exclamationMarks: Int)

--- a/src/main/scala/circelib/JsonSection.scala
+++ b/src/main/scala/circelib/JsonSection.scala
@@ -1,6 +1,7 @@
 /*
- * scala-exercises - exercises-circe
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-circe
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package circelib

--- a/src/main/scala/circelib/OpticsSection.scala
+++ b/src/main/scala/circelib/OpticsSection.scala
@@ -1,6 +1,7 @@
 /*
- * scala-exercises - exercises-circe
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-circe
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package circelib
@@ -121,7 +122,6 @@ object OpticsSection extends FlatSpec with Matchers with org.scalaexercises.defi
   }
 
   /**
-   *
    * ==Modifying JSON==
    *
    * Optics can also be used for making modifications to JSON.
@@ -138,13 +138,33 @@ object OpticsSection extends FlatSpec with Matchers with org.scalaexercises.defi
   }
 
   /**
+   * ==Recursively modifying JSON==
+   *
+   * Sometimes you may need to recursively modify JSON. Let assume you need to transform all numbers into strings in
+   * the example JSON:
+   */
+  def recursiveModifyJsonOptics(res0: Option[String]) = {
+    import io.circe.optics.JsonOptics._
+    import monocle.function.Plated
+
+    val recursiveModifiedJson = Plated.transform[Json] { j =>
+      json.asNumber match {
+        case Some(n) => Json.fromString(n.toString)
+        case None    => j
+      }
+    }(json)
+
+    root.order.total.string.getOption(recursiveModifiedJson) shouldBe res0
+  }
+
+  /**
    *
    * ==Dynamic==
    *
    * `JsonPath` relies on a feature of Scala called `Dynamic`. Using `Dynamic` you can call methods that don´t actually exist.
    * When you do so, the `selectDynamic` method is called, and the name of the method you wanted to call is passed as an argument.
    *
-   * The use of `Dynamic` means that your code is not "typo-safe". So be careful when you are typing
+   * '''WARNING:''' The use of `Dynamic` means that your code is not "typo-safe". So be careful when you are typing
    *
    * {{{
    *   val doubleQuantities: Json => Json =
@@ -161,4 +181,5 @@ object OpticsSection extends FlatSpec with Matchers with org.scalaexercises.defi
 
     modifiedQuantitiesDynamic == List(2, 4) should be(res0)
   }
+
 }

--- a/src/main/scala/circelib/OpticsSection.scala
+++ b/src/main/scala/circelib/OpticsSection.scala
@@ -28,7 +28,7 @@ object OpticsSection extends FlatSpec with Matchers with org.scalaexercises.defi
    *
    * Note that this will require your project to depend on both Scalaz and cats.
    *
-   * ==Traversing JSON==
+   * =Traversing JSON=
    *
    * Let´s try a few examples using this JSON document:
    *
@@ -36,26 +36,26 @@ object OpticsSection extends FlatSpec with Matchers with org.scalaexercises.defi
    *   val json: Json = parse("""
    *   {
    *     "order": {
-   *      "customer": {
-   *        "name": "Custy McCustomer",
-   *        "contactDetails": {
+   *       "customer": {
+   *         "name": "Custy McCustomer",
+   *         "contactDetails": {
    *           "address": "1 Fake Street, London, England",
    *           "phone": "0123-456-789"
-   *       }
-   *     },
-   *     "items": [{
-   *       "id": 123,
+   *         }
+   *       },
+   *       "items": [{
+   *         "id": 123,
    *         "description": "banana",
-   *        "quantity": 1
-   *     }, {
-   *        "id": 456,
+   *         "quantity": 1
+   *       }, {
+   *         "id": 456,
    *         "description": "apple",
-   *        "quantity": 2
-   *     }],
-   *     "total": 123.45
+   *         "quantity": 2
+   *       }],
+   *       "total": 123.45
    *     }
-   *     }
-   *     """).getOrElse(Json.Null)
+   *   }
+   * """).getOrElse(Json.Null)
    * }}}
    *
    * If we wanted to get the customer’s phone number, we could do it using a cursor as follows:
@@ -84,7 +84,7 @@ object OpticsSection extends FlatSpec with Matchers with org.scalaexercises.defi
    *
    * Now is your turn, let´s try your answer:
    */
-  def checkTraversingOptics(res0: Option[String]): Unit = {
+  def checkTraversingOptics(res0: Option[String]) = {
     val address: Option[String] = _address.getOption(json)
     address should be(res0)
   }
@@ -115,20 +115,20 @@ object OpticsSection extends FlatSpec with Matchers with org.scalaexercises.defi
    *
    * And with optics:
    */
-  def checkTraversingOptics2(res0: List[String]): Unit = {
+  def checkTraversingOptics2(res0: List[String]) = {
     val items: List[String] = root.order.items.each.description.string.getAll(json)
 
     items should be(res0)
   }
 
   /**
-   * ==Modifying JSON==
+   * =Modifying JSON=
    *
    * Optics can also be used for making modifications to JSON.
    *
    * In this example we will try modifiying the quantities. Let´s try your answer, `modifiedQuantities` would be...
    */
-  def modifyingJsonOptics(res0: List[Int]): Unit = {
+  def modifyingJsonOptics(res0: List[Int]) = {
     val doubleQuantities: Json => Json = root.order.items.each.quantity.int.modify(_ * 2)
 
     val modifiedJson = doubleQuantities(json)
@@ -138,7 +138,7 @@ object OpticsSection extends FlatSpec with Matchers with org.scalaexercises.defi
   }
 
   /**
-   * ==Recursively modifying JSON==
+   * =Recursively modifying JSON=
    *
    * Sometimes you may need to recursively modify JSON. Let assume you need to transform all numbers into strings in
    * the example JSON:
@@ -148,7 +148,7 @@ object OpticsSection extends FlatSpec with Matchers with org.scalaexercises.defi
     import monocle.function.Plated
 
     val recursiveModifiedJson = Plated.transform[Json] { j =>
-      json.asNumber match {
+      j.asNumber match {
         case Some(n) => Json.fromString(n.toString)
         case None    => j
       }
@@ -159,7 +159,7 @@ object OpticsSection extends FlatSpec with Matchers with org.scalaexercises.defi
 
   /**
    *
-   * ==Dynamic==
+   * =Dynamic=
    *
    * `JsonPath` relies on a feature of Scala called `Dynamic`. Using `Dynamic` you can call methods that don´t actually exist.
    * When you do so, the `selectDynamic` method is called, and the name of the method you wanted to call is passed as an argument.
@@ -175,7 +175,7 @@ object OpticsSection extends FlatSpec with Matchers with org.scalaexercises.defi
    *
    * Let´s see the result for the last affirmation
    */
-  def modifyingJsonDynamic(res0: Boolean): Unit = {
+  def modifyingJsonDynamic(res0: Boolean) = {
     val modifiedQuantitiesDynamic: List[Int] =
       root.order.items.each.quantity.int.getAll(modifiedJson)
 

--- a/src/main/scala/circelib/TraversingSection.scala
+++ b/src/main/scala/circelib/TraversingSection.scala
@@ -24,26 +24,25 @@ object TraversingSection
    *
    * Suppose we have the following JSON document:
    *
-   *
    * {{{
-   *     import cats.syntax.either._
-   *     import io.circe._, io.circe.parser._
+   * import cats.syntax.either._
+   * import io.circe._, io.circe.parser._
    *
-   *     val json: String = """
-   *     {
-   *       "id": "c730433b-082c-4984-9d66-855c243266f0",
-   *       "name": "Foo",
-   *       "counts": [1, 2, 3],
-   *       "values": {
-   *       "bar": true,
-   *       "baz": 100.001,
-   *       "qux": ["a", "b"]
-   *       }
-   *     } """
+   * val json: String = """
+   * {
+   *   "id": "c730433b-082c-4984-9d66-855c243266f0",
+   *   "name": "Foo",
+   *   "counts": [1, 2, 3],
+   *   "values": {
+   *   "bar": true,
+   *   "baz": 100.001,
+   *   "qux": ["a", "b"]
+   *   }
+   * } """
    *
-   *    val doc: Json = parse(json).getOrElse(Json.Null)
+   * val doc: Json = parse(json).getOrElse(Json.Null)
    * }}}
-   * ==Extracting data==
+   * =Extracting data=
    *
    * In order to traverse we need to create an `HCursor` with the focus at the document’s root
    *
@@ -53,7 +52,7 @@ object TraversingSection
    *
    * We can then use various operations to move the focus of the cursor around the document and extract data from it
    */
-  def moveFocus(res0: Either[String, Double]): Unit = {
+  def moveFocus(res0: Either[String, Double]) = {
     val baz: Decoder.Result[Double] = cursor.downField("values").downField("baz").as[Double]
 
     baz should be(res0)
@@ -64,7 +63,7 @@ object TraversingSection
    *
    * What would be the result in this case?
    */
-  def moveFocus2(res0: Either[String, Double]): Unit = {
+  def moveFocus2(res0: Either[String, Double]) = {
     val baz2: Decoder.Result[Double] = cursor.downField("values").get[Double]("baz")
 
     baz2 should be(res0)
@@ -75,7 +74,7 @@ object TraversingSection
    *
    * What would the result be when traversing through the array?
    */
-  def moveFocus3(res0: Either[String, String]): Unit = {
+  def moveFocus3(res0: Either[String, String]) = {
     val secondQux: Decoder.Result[String] =
       cursor.downField("values").downField("qux").downArray.right.as[String]
 
@@ -83,7 +82,7 @@ object TraversingSection
   }
 
   /**
-   * ==Transforming data==
+   * =Transforming data=
    *
    * In this section we are going to learn how to use a cursor to modify JSON
    *
@@ -110,7 +109,7 @@ object TraversingSection
    *
    * The result contains the original document, but what would be the result for "name" field?
    */
-  def modifyJson(res0: Either[String, String]): Unit = {
+  def modifyJson(res0: Either[String, String]) = {
 
     val nameResult: Result[String] =
       cursor.downField("name").withFocus(_.mapString(_.reverse)).as[String]

--- a/src/main/scala/circelib/TraversingSection.scala
+++ b/src/main/scala/circelib/TraversingSection.scala
@@ -1,6 +1,7 @@
 /*
- * scala-exercises - exercises-circe
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-circe
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package circelib

--- a/src/main/scala/circelib/helpers/ADTHelpers.scala
+++ b/src/main/scala/circelib/helpers/ADTHelpers.scala
@@ -1,0 +1,66 @@
+/*
+ *  scala-exercises - exercises-circe
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ */
+
+package circelib.helpers
+
+import cats.syntax.functor._
+import io.circe.{Decoder, Encoder}
+import io.circe.generic.auto._
+import io.circe.syntax._
+
+object ADTHelpers {
+  sealed trait Event
+
+  case class Foo(i: Int)               extends Event
+  case class Bar(s: String)            extends Event
+  case class Baz(c: Char)              extends Event
+  case class Qux(values: List[String]) extends Event
+
+  object GenericDerivation {
+
+    implicit val encodeEvent: Encoder[Event] = Encoder.instance {
+      case foo @ Foo(_) => foo.asJson
+      case bar @ Bar(_) => bar.asJson
+      case baz @ Baz(_) => baz.asJson
+      case qux @ Qux(_) => qux.asJson
+    }
+
+    implicit val decodeEvent: Decoder[Event] =
+      List[Decoder[Event]](
+        Decoder[Foo].widen,
+        Decoder[Bar].widen,
+        Decoder[Baz].widen,
+        Decoder[Qux].widen
+      ).reduceLeft(_ or _)
+  }
+
+  // TODO: Having problems with this exercise (https://github.com/circe/circe/issues/1125)
+  /*// To suppress previously imported implicit codecs.
+  import GenericDerivation.{decodeEvent => _, encodeEvent => _}
+
+  object ShapesDerivation {
+    import shapeless.{Coproduct, Generic}
+
+    implicit def encodeAdtNoDiscr[A, Repr <: Coproduct](
+        implicit
+        gen: Generic.Aux[A, Repr],
+        encodeRepr: Encoder[Repr]): Encoder[A] = encodeRepr.contramap(gen.to)
+
+    implicit def decodeAdtNoDiscr[A, Repr <: Coproduct](
+        implicit
+        gen: Generic.Aux[A, Repr],
+        decodeRepr: Decoder[Repr]): Decoder[A] = decodeRepr.map(gen.from)
+
+  }*/
+
+  object GenericExtraDerivation {
+    import io.circe.generic.extras.Configuration
+
+    implicit val genDevConfig: Configuration =
+      Configuration.default.withDiscriminator("what_am_i")
+  }
+
+}

--- a/src/main/scala/circelib/helpers/ADTHelpers.scala
+++ b/src/main/scala/circelib/helpers/ADTHelpers.scala
@@ -7,8 +7,7 @@
 package circelib.helpers
 
 import cats.syntax.functor._
-import io.circe.{Decoder, Encoder}
-import io.circe.generic.auto._
+import io.circe.{Decoder, Encoder}, io.circe.generic.auto._
 import io.circe.syntax._
 
 object ADTHelpers {
@@ -37,10 +36,6 @@ object ADTHelpers {
       ).reduceLeft(_ or _)
   }
 
-  // TODO: Having problems with this exercise (https://github.com/circe/circe/issues/1125)
-  /*// To suppress previously imported implicit codecs.
-  import GenericDerivation.{decodeEvent => _, encodeEvent => _}
-
   object ShapesDerivation {
     import shapeless.{Coproduct, Generic}
 
@@ -54,7 +49,7 @@ object ADTHelpers {
         gen: Generic.Aux[A, Repr],
         decodeRepr: Decoder[Repr]): Decoder[A] = decodeRepr.map(gen.from)
 
-  }*/
+  }
 
   object GenericExtraDerivation {
     import io.circe.generic.extras.Configuration

--- a/src/main/scala/circelib/helpers/CustomCodecsHelpers.scala
+++ b/src/main/scala/circelib/helpers/CustomCodecsHelpers.scala
@@ -1,14 +1,15 @@
 /*
- * scala-exercises - exercises-circe
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-circe
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package circelib.helpers
 
-import io.circe._
+import io.circe.KeyEncoder
 import io.circe.syntax._
 
-object EncodingHelpers {
+object CustomCodecsHelpers {
 
   case class Foo(value: String)
   // defined class Foo

--- a/src/main/scala/circelib/helpers/JsonHelpers.scala
+++ b/src/main/scala/circelib/helpers/JsonHelpers.scala
@@ -1,6 +1,7 @@
 /*
- * scala-exercises - exercises-circe
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-circe
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package circelib.helpers

--- a/src/main/scala/circelib/helpers/OpticsHelpers.scala
+++ b/src/main/scala/circelib/helpers/OpticsHelpers.scala
@@ -1,11 +1,11 @@
 /*
- * scala-exercises - exercises-circe
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-circe
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package circelib.helpers
 
-import cats.syntax.either._
 import io.circe._, io.circe.parser._
 import io.circe.optics.JsonPath._
 

--- a/src/main/scala/circelib/helpers/TraversingHelpers.scala
+++ b/src/main/scala/circelib/helpers/TraversingHelpers.scala
@@ -1,11 +1,11 @@
 /*
- * scala-exercises - exercises-circe
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-circe
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package circelib.helpers
 
-import cats.syntax.either._
 import io.circe.{ACursor, HCursor, Json}
 import io.circe.parser.parse
 

--- a/src/test/scala/circelib/ADTSpec.scala
+++ b/src/test/scala/circelib/ADTSpec.scala
@@ -1,0 +1,37 @@
+/*
+ *  scala-exercises - exercises-circe
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ */
+
+package circelib
+
+import circelib.helpers.ADTHelpers.{Event, Foo}
+import org.scalacheck.ScalacheckShapeless._
+import org.scalaexercises.Test
+import org.scalatest.refspec.RefSpec
+import org.scalatestplus.scalacheck.Checkers
+import shapeless.HNil
+
+class ADTSpec extends RefSpec with Checkers {
+
+  def `generic derivation`() =
+    check(
+      Test.testSuccess(
+        ADTSection.genericDerivation _,
+        (Right(Foo(1000)): Either[String, Event]) :: """{"i":100}""" :: HNil))
+
+  def `shapes derivation`() =
+    check(
+      Test.testSuccess(
+        ADTSection.shapesDerivation _,
+        (Right(Foo(1000)): Either[String, Event]) :: """{"i":100}""" :: HNil))
+
+  def `generic extras ADT`() =
+    check(
+      Test
+        .testSuccess(
+          ADTSection.genericExtrasADT _,
+          (Right(Foo(1000)): Either[String, Event]) :: HNil))
+
+}

--- a/src/test/scala/circelib/CustomCodecsSpec.scala
+++ b/src/test/scala/circelib/CustomCodecsSpec.scala
@@ -1,0 +1,42 @@
+/*
+ *  scala-exercises - exercises-circe
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ */
+
+package circelib
+
+import org.scalacheck.ScalacheckShapeless._
+import org.scalaexercises.Test
+import org.scalatest.refspec.RefSpec
+import org.scalatestplus.scalacheck.Checkers
+import shapeless.HNil
+
+class CustomCodecsSpec extends RefSpec with Checkers {
+
+  import CustomCodecsSection._
+
+  def `map Json` = {
+    check(
+      Test.testSuccess(
+        mapJson _,
+        (Right[String, Int](123): Either[String, Int]) :: HNil
+      )
+    )
+  }
+
+  def `basic custom key mapping` =
+    check(
+      Test.testSuccess(
+        basicCustomKeyMapping _,
+        """{"first_name":"Foo","last_name":"McBar"}""" :: HNil
+      )
+    )
+
+  def `complex custom key mapping` =
+    check(Test.testSuccess(complexCustomKeyMapping _, """{"my-int":13,"s":"Qux"}""" :: HNil))
+
+  def `mapping member annotation` =
+    check(Test.testSuccess(mappingMemberAnnotation _, """{"my-int":13,"s":"Qux"}""" :: HNil))
+
+}

--- a/src/test/scala/circelib/EncodingDecodingSpec.scala
+++ b/src/test/scala/circelib/EncodingDecodingSpec.scala
@@ -1,17 +1,18 @@
 /*
- * scala-exercises - exercises-circe
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-circe
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package circelib
 
 import org.scalaexercises.Test
-import org.scalacheck.Shapeless._
-import org.scalatest.Spec
-import org.scalatest.prop.Checkers
+import org.scalacheck.ScalacheckShapeless._
+import org.scalatest.refspec.RefSpec
+import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 
-class EncodingDecodingSpec extends Spec with Checkers {
+class EncodingDecodingSpec extends RefSpec with Checkers {
 
   def `decode Json` = {
     check(
@@ -27,15 +28,6 @@ class EncodingDecodingSpec extends Spec with Checkers {
       Test.testSuccess(
         EncodingDecodingSection.automaticDerivation _,
         (Right[String, String]("Chris"): Either[String, String]) :: HNil
-      )
-    )
-  }
-
-  def `map Json` = {
-    check(
-      Test.testSuccess(
-        EncodingDecodingSection.mapJson _,
-        (Right[String, Int](123): Either[String, Int]) :: HNil
       )
     )
   }

--- a/src/test/scala/circelib/JsonSpec.scala
+++ b/src/test/scala/circelib/JsonSpec.scala
@@ -1,19 +1,20 @@
 /*
- * scala-exercises - exercises-circe
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-circe
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package circelib
 
 import io.circe.Json
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
-import org.scalatest.prop.Checkers
+import org.scalatest.refspec.RefSpec
+import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 import circelib.utils.JsonArbitraries
 
-class JsonSpec extends Spec with Checkers {
+class JsonSpec extends RefSpec with Checkers {
 
   import JsonArbitraries._
 

--- a/src/test/scala/circelib/OpticsSpec.scala
+++ b/src/test/scala/circelib/OpticsSpec.scala
@@ -1,17 +1,18 @@
 /*
- * scala-exercises - exercises-circe
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-circe
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package circelib
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
-import org.scalatest.prop.Checkers
+import org.scalatest.refspec.RefSpec
+import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 
-class OpticsSpec extends Spec with Checkers {
+class OpticsSpec extends RefSpec with Checkers {
 
   def `check traversing optics` = {
     check(
@@ -36,6 +37,15 @@ class OpticsSpec extends Spec with Checkers {
       Test.testSuccess(
         OpticsSection.modifyingJsonOptics _,
         List(2, 4) :: HNil
+      )
+    )
+  }
+
+  def `recursively modify optics` = {
+    check(
+      Test.testSuccess(
+        OpticsSection.recursiveModifyJsonOptics _,
+        Option("123.45") :: HNil
       )
     )
   }

--- a/src/test/scala/circelib/TraversingSpec.scala
+++ b/src/test/scala/circelib/TraversingSpec.scala
@@ -1,17 +1,18 @@
 /*
- * scala-exercises - exercises-circe
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-circe
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package circelib
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
-import org.scalatest.prop.Checkers
+import org.scalatest.refspec.RefSpec
+import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 
-class TraversingSpec extends Spec with Checkers {
+class TraversingSpec extends RefSpec with Checkers {
 
   def `move as` = {
     check(

--- a/src/test/scala/circelib/utils/JsonArbitraries.scala
+++ b/src/test/scala/circelib/utils/JsonArbitraries.scala
@@ -1,6 +1,7 @@
 /*
- * scala-exercises - exercises-circe
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-circe
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package circelib.utils

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.4.2-SNAPSHOT"
+version in ThisBuild := "0.5.0-SNAPSHOT"


### PR DESCRIPTION
This PR updates library to Scala 2.12.10 and it's dependencies. Added compatibility with Scala Exercises 0.5.0-SNAPSHOT. There's still some warnings about unused implicit values but are being used.