### PR TITLE
change the typesignature for the mapArray method in transformJson

### DIFF
--- a/src/main/scala/circelib/JsonSection.scala
+++ b/src/main/scala/circelib/JsonSection.scala
@@ -143,7 +143,7 @@ object JsonSection extends AnyFlatSpec with Matchers with definitions.Section {
    *
    * {{{
    *   def transformJson(jsonArray: Json): Json =
-   *     jsonArray mapArray { oneJson: List[Json] =>
+   *     jsonArray mapArray { oneJson: Vector[Json] =>
    *       oneJson.init
    *     }
    * }}}


### PR DESCRIPTION
In the last exercise of the JSON section of the circe-exercises codebase there's an example implementation of transforming JSON that takes this JSON array 
```
val jsonArray: Json = Json.fromValues(List(
  Json.fromFields(List(("field1", Json.fromInt(1)))),
  Json.fromFields(List(
    ("field1", Json.fromInt(200)),
    ("field2", Json.fromString("Having circe in Scala Exercises is awesome"))))))
``` 

and introduces a transformation method that modifies the first field of that jsonArray
```
def transformJson(jsonArray: Json): Json =
  jsonArray mapArray { oneJson: List[Json] =>
    oneJson.init
  }
```

This all makes sense in terms of an implementation, but the type signature of the `mapArray` function inside the transformJson method isn't quite correct.  Under the hood, circe transforms the first json array entry (`field1`) into a _`Vector`_ not a _`List`_, and therefore the type signature of the `oneJson` parameter should be `Vector[Json]` instead of `List[Json]`.  

I've provided the following Scastie example to show the compiler error that surfaces when trying to use the incorrect type signature: https://scastie.scala-lang.org/zN4i9CU7TBqpEzfBFacBow

Please let me know if this change doesn't make sense (I haven't worked with circe too much before since I come from akka-land), but hopefully I'm on the right track.